### PR TITLE
fix: change style for displaying text in adaptive dialog

### DIFF
--- a/lib/screens/home/home_controller.dart
+++ b/lib/screens/home/home_controller.dart
@@ -133,6 +133,7 @@ class HomeScreenController extends State<HomeScreen> {
           (!validURL
               ? "No valid Product Link or unsupported Store Link found in the Clipboard!"
               : "Valid Link pasted from the Clipboard!"),
+      style: AdaptiveStyle.material,
     ));
     input = inputs != null ? inputs[0] : inputs;
 


### PR DESCRIPTION
Now, Text is readable.
It seems that in the AdaptiveStyle.adaptive (default), the text is shown black on black (non-readable). When switching to AdaptiveStyle.material, then it shows correctly, also on iOS.