### PR TITLE
fix: new prop favorXPath in parser_configuration

### DIFF
--- a/lib/configuration/parser_configuration.json
+++ b/lib/configuration/parser_configuration.json
@@ -2,6 +2,7 @@
     "domains": {
         "amazon.de": {
             "xpath": "false",
+            "favorXPath": "false",
             "name": [{
                 "path": "#productTitle",
                 "regex": {
@@ -57,6 +58,7 @@
         },
         "amazon.com": {
             "xpath": "false",
+            "favorXPath": "false",
             "name": [{
                 "path": "#productTitle",
                 "regex": {
@@ -112,6 +114,7 @@
         },
         "officeworld.ch": {
             "xpath": "true",
+            "favorXPath": "false",
             "name": [{
                 "path": "//*[@id='pageHeader']/div[1]/div/div[2]/div[1]/h1",
                 "regex": {
@@ -142,6 +145,7 @@
         },
         "exlibris.ch": {
             "xpath": "true",
+            "favorXPath": "false",
             "name": [{
                 "path": "//*[@id='nameStructural']",
                 "regex": {
@@ -172,6 +176,45 @@
                     "regex": {
                         "attribute": "src",
                         "pattern": "src=\"(\\S*)\"",
+                        "remove": "",
+                        "group": 1
+                    }
+                }
+            ]
+        },
+        "unrealengine.com": {
+            "xpath": "true",
+            "favorXPath": "true",
+            "name": [{
+                "path": "//*[@id='epic-marketplace']/div/div/div[1]/section[1]/div[2]/div[1]/div[1]/h1",
+                "regex": {
+                    "pattern": ">\\s*(.*)\\s*<",
+                    "remove": "",
+                    "group": 1
+                }
+            }],
+            "price": [{
+                    "path": "//*[@id='epic-marketplace']/div/div/div[1]/section[1]/div[2]/div[2]/div/div[1]/div/div/span",
+                    "regex": {
+                        "pattern": "(\\d+[,.]?[\\d]*)",
+                        "remove": "",
+                        "group": 1
+                    }
+                },
+                {
+                    "path": "//*[@id='epic-marketplace']/div/div/div[1]/section[1]/div[2]/div[2]/div/div[1]/div/div/div/span/span",
+                        "regex": {
+                            "pattern": "(\\d+[,.]?[\\d]*)",
+                            "remove": "",
+                            "group": 1
+                    }
+                }
+            ],
+            "image": [{
+                    "path": "//meta[@property='og:image']",
+                    "regex": {
+                        "attribute": "content",
+                        "pattern": "content=\"(\\S*)\"",
                         "remove": "",
                         "group": 1
                     }

--- a/lib/services/scraper.dart
+++ b/lib/services/scraper.dart
@@ -165,7 +165,14 @@ class ScraperService {
 
     String d = ScraperService.getDomain(url);
     dynamic sdJSON = getStructuredDataJSON(r);
-    if (sdJSON != null)
+    if (parseableDomains.contains(d) &&
+        toBoolean(parserConf["domains"][d]["xpath"]) &&
+        toBoolean(parserConf["domains"][d]["favorXPath"]))
+      // Edge case for when a page's content includes JSON-LD (sdJSON) but the
+      // data (e.g. price, name) is outdated/wrong compared to what can be
+      // scraped with ParserXPath
+      return ParserXPath(url, r);
+    else if (sdJSON != null)
       return ParserSD(url, r, sdJSON);
     else if (parseableDomains.contains(d)) {
       if (toBoolean(parserConf["domains"][d]["xpath"]))


### PR DESCRIPTION
Add new boolean property "favorXPath" in parser_configuration.json

In some cases, a page's content may include JSON-LD (sdJSON) but
the data (e.g. price, name) is outdated/wrong compared to what can
be scraped with ParserXPath (this is the case with products pages
on unrealengine.com/marketplace for example).
In this case, the property "favorXPath" can be set to "true" for
a specific domain in order to ignore the problematic JSON-LD data.

Closes #55